### PR TITLE
Fix regex quoting for hotspot credentials

### DIFF
--- a/mobile-hotspot-manager.ps1
+++ b/mobile-hotspot-manager.ps1
@@ -312,7 +312,7 @@ function Get-MobileHotspotCredentials {
         $passphrase = $null
 
         foreach ($line in $ssidOutput) {
-            if ($line -match "SSID name\s*:\s*\"?(.+?)\"?$") {
+            if ($line -match 'SSID name\s*:\s*"?(.*?)"?$') {
                 $ssid = $matches[1].Trim()
                 break
             }


### PR DESCRIPTION
## Summary
- fix the regex used to parse SSID in the `Get-MobileHotspotCredentials` fallback path

## Testing
- `pwsh -NoProfile -File mobile-hotspot-manager.ps1 -Action Help | head -n 20`
- `pwsh -NoProfile -File mobile-hotspot-manager.ps1 -Action GetHotspot | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688ac516c3408323a91b5c19243be496